### PR TITLE
Add config to disable resizing in PvP battles

### DIFF
--- a/common/src/main/java/dev/cudzer/cobblemonsizevariation/config/ConfigKey.java
+++ b/common/src/main/java/dev/cudzer/cobblemonsizevariation/config/ConfigKey.java
@@ -8,6 +8,7 @@ public class ConfigKey {
     public static final String PREVENT_RIDING_MAX_SIZE = "preventRidingMaxSize";
     public static final String SIZING_ALGORITHM = "sizingAlgorithm";
     public static final String BIAS_SIZE_TOWARD_AVERAGE = "biasSizeTowardAverage";
+    public static final String DISABLE_RESIZING_IN_PVP = "disableResizingInPvP";
 
     //SIZE DEFINITION KEYS
     public static final String SIZE_DEFINITION_NAME = "name";

--- a/common/src/main/java/dev/cudzer/cobblemonsizevariation/config/ModConfig.java
+++ b/common/src/main/java/dev/cudzer/cobblemonsizevariation/config/ModConfig.java
@@ -24,6 +24,7 @@ public class ModConfig {
 
     public static boolean biasSizeTowardAverage;
     public static boolean enableEssenceRecipes;
+    public static boolean disableResizingInPvP;
 
     public static HashMap<String, Integer> perms = new HashMap<>();
 
@@ -66,6 +67,7 @@ public class ModConfig {
         defaultConfig.addProperty(ConfigKey.SIZING_ALGORITHM, "basic");
         defaultConfig.addProperty(ConfigKey.BIAS_SIZE_TOWARD_AVERAGE, false);
         defaultConfig.addProperty(ConfigKey.ENABLE_ESSENCE_RECIPES, false);
+        defaultConfig.addProperty(ConfigKey.DISABLE_RESIZING_IN_PVP, true);
     }
 
     private static void rewriteConfig(Gson gson, JsonObject defaultConfig, JsonObject finalConfig){
@@ -94,6 +96,7 @@ public class ModConfig {
         sizingAlgorithm = finalConfiguration.get(ConfigKey.SIZING_ALGORITHM).getAsString();
         biasSizeTowardAverage = finalConfiguration.get(ConfigKey.BIAS_SIZE_TOWARD_AVERAGE).getAsBoolean();
         enableEssenceRecipes = finalConfiguration.get(ConfigKey.ENABLE_ESSENCE_RECIPES).getAsBoolean();
+        disableResizingInPvP = finalConfiguration.get(ConfigKey.DISABLE_RESIZING_IN_PVP).getAsBoolean();
         JsonArray permissionConfig = finalConfiguration.get(ConfigKey.PERMISSIONS).getAsJsonArray();
 
         perms.clear();

--- a/common/src/main/java/dev/cudzer/cobblemonsizevariation/event/ModEvents.java
+++ b/common/src/main/java/dev/cudzer/cobblemonsizevariation/event/ModEvents.java
@@ -2,12 +2,17 @@ package dev.cudzer.cobblemonsizevariation.event;
 
 import com.cobblemon.mod.common.api.Priority;
 import com.cobblemon.mod.common.api.events.CobblemonEvents;
+import com.cobblemon.mod.common.api.events.battles.BattleFledEvent;
+import com.cobblemon.mod.common.api.events.battles.BattleStartedEvent;
+import com.cobblemon.mod.common.api.events.battles.BattleVictoryEvent;
 import com.cobblemon.mod.common.api.events.entity.SpawnEvent;
 import com.cobblemon.mod.common.api.events.cooking.PokeSnackSpawnPokemonEvent;
 import com.cobblemon.mod.common.api.events.pokemon.FossilRevivedEvent;
 import com.cobblemon.mod.common.api.events.pokemon.ShoulderMountEvent;
 import com.cobblemon.mod.common.api.events.pokemon.RidePokemonEvent;
 import com.cobblemon.mod.common.api.events.starter.StarterChosenEvent;
+import com.cobblemon.mod.common.api.battles.model.PokemonBattle;
+import com.cobblemon.mod.common.battles.BattleRegistry;
 import com.cobblemon.mod.common.entity.pokemon.PokemonEntity;
 import com.cobblemon.mod.common.pokemon.Pokemon;
 import dev.cudzer.cobblemonsizevariation.CobblemonSizeVariation;
@@ -18,11 +23,16 @@ import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.MutableComponent;
 import net.minecraft.server.level.ServerPlayer;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Random;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
 
 public class ModEvents {
     private static final Random random = new Random();
+    private static final Map<UUID, Map<UUID, Float>> pvpBattleOriginalScales = new ConcurrentHashMap<>();
 
     public static void registerEvents(){
         CobblemonEvents.POKEMON_ENTITY_SPAWN.subscribe(Priority.NORMAL, ModEvents::onCobblemonSpawn);
@@ -31,6 +41,9 @@ public class ModEvents {
         CobblemonEvents.STARTER_CHOSEN.subscribe(Priority.NORMAL, ModEvents::onStarterChosen);
         CobblemonEvents.FOSSIL_REVIVED.subscribe(Priority.NORMAL, ModEvents::onFossilRevived);
         CobblemonEvents.RIDE_EVENT_PRE.subscribe(Priority.NORMAL, ModEvents::onAttemptRide);
+        CobblemonEvents.BATTLE_STARTED_POST.subscribe(Priority.NORMAL, ModEvents::onBattleStarted);
+        CobblemonEvents.BATTLE_VICTORY.subscribe(Priority.NORMAL, ModEvents::onBattleVictory);
+        CobblemonEvents.BATTLE_FLED.subscribe(Priority.NORMAL, ModEvents::onBattleFled);
     }
 
     private static void onCobblemonSpawn(SpawnEvent<PokemonEntity> event){
@@ -77,11 +90,76 @@ public class ModEvents {
         resizer(event.getPokemon(), event.getPlayer(), true);
     }
 
+    private static void onBattleStarted(BattleStartedEvent.Post event){
+        if(!ModConfig.disableResizingInPvP) return;
+
+        PokemonBattle battle = event.getBattle();
+        if(!battle.isPvP()) return;
+
+        Map<UUID, Float> originalScales = new HashMap<>();
+        for(var actor : battle.getActors()){
+            for(var battlePokemon : actor.getPokemonList()){
+                Pokemon p = battlePokemon.getEffectedPokemon();
+                UUID pokemonUuid = p.getUuid();
+
+                originalScales.putIfAbsent(pokemonUuid, p.getScaleModifier());
+                if(p.getScaleModifier() != 1.0f){
+                    p.setScaleModifier(1.0f);
+                    syncScaleToBattlePlayers(battle, p, 1.0f);
+                }
+            }
+        }
+
+        if(!originalScales.isEmpty()){
+            pvpBattleOriginalScales.put(battle.getBattleId(), originalScales);
+        }
+    }
+
+    private static void onBattleVictory(BattleVictoryEvent event){
+        restoreBattleScales(event.getBattle());
+    }
+
+    private static void onBattleFled(BattleFledEvent event){
+        restoreBattleScales(event.getBattle());
+    }
+
+    private static void restoreBattleScales(PokemonBattle battle){
+        Map<UUID, Float> originalScales = pvpBattleOriginalScales.remove(battle.getBattleId());
+        if(originalScales == null || originalScales.isEmpty()) return;
+
+        for(var actor : battle.getActors()){
+            for(var battlePokemon : actor.getPokemonList()){
+                Pokemon p = battlePokemon.getEffectedPokemon();
+                Float originalScale = originalScales.get(p.getUuid());
+                if(originalScale != null && p.getScaleModifier() != originalScale){
+                    p.setScaleModifier(originalScale);
+                    syncScaleToBattlePlayers(battle, p, originalScale);
+                }
+            }
+        }
+    }
+
+    private static void syncScaleToBattlePlayers(PokemonBattle battle, Pokemon pokemon, double scale){
+        for(ServerPlayer battlePlayer : battle.getPlayers()){
+            CobblemonSizeVariation.platform.getNetworkManager().sendPacketToPlayer(
+                    battlePlayer,
+                    new SizeChangedPacket(() -> pokemon, scale)
+            );
+        }
+    }
+
     private static boolean canModifySize(){
         return random.nextFloat() < ModConfig.sizeModificationChance;
     }
 
     private static void resizer(Pokemon pokemon, ServerPlayer player, boolean requireClientUpdate){
+        if(player != null && ModConfig.disableResizingInPvP){
+            PokemonBattle currentBattle = BattleRegistry.getBattleByParticipatingPlayer(player);
+            if(currentBattle != null && currentBattle.isPvP()){
+                return;
+            }
+        }
+
         if(canModifySize()){
             double sizeModifier;
             var customSize = CustomSizeDataManager.getCustomSizeFile(pokemon.getSpecies());


### PR DESCRIPTION
This PR adds an optional PvP safeguard that prevents Pokemon size randomness from affecting PvP battles.

When enabled, participating Pokemon are temporarily normalized to scale 1.0 at PvP battle start, and their original scales are restored when the battle ends (victory or flee).